### PR TITLE
Fill event should use trade price

### DIFF
--- a/program/src/state/event_queue.rs
+++ b/program/src/state/event_queue.rs
@@ -26,8 +26,8 @@ pub struct FillEvent {
     pub taker_side: u8,
     /// zero padding for alignment
     pub _padding: [u8; 6],
-    /// The total quote size of the transaction
-    pub quote_size: u64,
+    /// The trade price of the order fill
+    pub trade_price: u64,
     /// The order id of the maker order
     pub maker_order_id: u128,
     /// The total base size of the transaction
@@ -349,7 +349,7 @@ mod tests {
                             tag: EventTag::Fill as u8,
                             taker_side: Side::Ask as u8,
                             _padding: [0; 6],
-                            quote_size: seq_gen.next().unwrap(),
+                            trade_price: seq_gen.next().unwrap(),
                             maker_order_id: seq_gen.next().unwrap() as u128,
                             base_size: seq_gen.next().unwrap(),
                         },
@@ -377,7 +377,7 @@ mod tests {
             tag: EventTag::Fill as u8,
             taker_side: Side::Ask as u8,
             _padding: [0; 6],
-            quote_size: seq_gen.next().unwrap(),
+            trade_price: seq_gen.next().unwrap(),
             maker_order_id: seq_gen.next().unwrap() as u128,
             base_size: seq_gen.next().unwrap(),
         };
@@ -419,7 +419,7 @@ mod tests {
                                 tag: EventTag::Fill as u8,
                                 taker_side: Side::Ask as u8,
                                 _padding: [0; 6],
-                                quote_size: seq_gen.next().unwrap(),
+                                trade_price: seq_gen.next().unwrap(),
                                 maker_order_id: seq_gen.next().unwrap() as u128,
                                 base_size: seq_gen.next().unwrap(),
                             },

--- a/program/src/state/orderbook.rs
+++ b/program/src/state/orderbook.rs
@@ -224,7 +224,7 @@ where
             let maker_fill = FillEvent {
                 taker_side: side as u8,
                 maker_order_id: best_bo_ref.order_id(),
-                quote_size: quote_maker_qty,
+                trade_price,
                 base_size: base_trade_qty,
                 tag: EventTag::Fill as u8,
                 _padding: [0; 6],
@@ -663,7 +663,7 @@ mod tests {
                     tag: EventTag::Fill as u8,
                     taker_side: Side::Ask as u8,
                     _padding: [0; 6],
-                    quote_size: 500_000 * 15,
+                    trade_price: 15 << 32,
                     maker_order_id: bob_order_id_0.unwrap(),
                     base_size: 500_000
                 },


### PR DESCRIPTION
Fill events were using quote filled values, while orderbook posts only stored base values. This causes complexity when deriving the quote in a post and comparing against a fill event. To maintain consistency, the `FillEvent` now tracks the price at which a fill was generated.